### PR TITLE
dependabot groups: Split out sizes

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,9 +1,11 @@
 version: 2
 updates:
+
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:
       interval: "weekly"
+
   - package-ecosystem: "cargo" # See documentation for possible values
     directory: "/" # Location of package manifests
     schedule:
@@ -12,11 +14,31 @@ updates:
       opentelemetry:
           patterns:
             - "*opentelemetry*"
-      dependencies:
+      patch-dependencies:
           patterns:
             - "*"
           exclude-patterns:
             - "*opentelemetry*"
+          update-types:
+            - "patch"
+      minor-dependencies:
+          patterns:
+            - "*"
+          exclude-patterns:
+            - "*opentelemetry*"
+          update-types:
+            - "minor"
+            - "patch"
+      major-dependencies:
+          patterns:
+            - "*"
+          exclude-patterns:
+            - "*opentelemetry*"
+          update-types:
+            - "minor"
+            - "patch"
+            - "major"
+
   - package-ecosystem: "docker" # See documentation for possible values
     directory: "/" # Location of package manifests
     schedule:


### PR DESCRIPTION
In case larger updates break something with incompatible changes, group each level (and smaller).